### PR TITLE
fix(compile): Upgrade TypeScript to v4.1.3 in order to fix compile command

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "ts-loader": "^5.2.1",
-    "typescript": "~2.4.1",
+    "typescript": "^4.1.3",
     "vscode": "^1.1.4",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.2"


### PR DESCRIPTION
I've faced with issue that did't allow to compile typescript files in order to publish extension to [Open VSX](https://open-vsx.org/) registry due to issue during compilation.

I've upgraded TypeScript to v4.1.3 to fix this issue.

![image](https://user-images.githubusercontent.com/1110697/102997494-f8814b80-452d-11eb-9d86-d4f085967823.png)
